### PR TITLE
Fix cosign signing and remove arm64 image

### DIFF
--- a/.github/workflows/lint-test-publish.yml
+++ b/.github/workflows/lint-test-publish.yml
@@ -162,7 +162,7 @@ jobs:
           file: deployments/docker/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
       - id: maintag
         name: extract main tag
@@ -188,10 +188,12 @@ jobs:
               -a sha=${{ github.sha }} \
               -a run_id=${{ github.run_id }} \
               -a run_attempt=${{ github.run_attempt }} \
-              -a tag=${{ steps.maintag.outputs.maintag }}
+              -a tag=${{ steps.maintag.outputs.maintag }} \
+              -y
           cosign sign \
               yorinasub17/tiktoken-grpc@${{ steps.publish.outputs.digest }} \
               -a sha=${{ github.sha }} \
               -a run_id=${{ github.run_id }} \
               -a run_attempt=${{ github.run_attempt }} \
-              -a tag=${{ steps.maintag.outputs.maintag }}
+              -a tag=${{ steps.maintag.outputs.maintag }} \
+              -y


### PR DESCRIPTION
This fixes the broken cosign signing in the previous build.

This also removes arm64 images for now due to the cross compiling taking a whopping 2 hours (!). The intention is to use the [arm builders on circleci](https://circleci.com/execution-environments/arm/) to handle this, but that will come in a later PR.